### PR TITLE
refactor(globals): move globals

### DIFF
--- a/docker/.editorconfig
+++ b/docker/.editorconfig
@@ -8,3 +8,4 @@ indent_size = 4
 
 [*.md]
 trim_trailing_whitespace = false
+indent_size = 2

--- a/docker/README.md
+++ b/docker/README.md
@@ -17,17 +17,21 @@ $ docker run -d -p 3030:80 --name radar-dashboard radarcns/radar-dashboard:lates
 
 The dashboard will be running at http://localhost:3030
 
-## Runtime environment variables  
+## Environment parameters  
 
-Environment variables can be overridden by `docker-compose` because they're used in the `docker run` command instead of `docker build`. More information in [https://docs.docker.com](https://docs.docker.com/compose/environment-variables/#/setting-environment-variables-in-containers). This comes at a cost, it needs to get the files from github and build them the first time it runs, but it only does this once and there's added flexibility to clone other github branches for testing or other purposes.
+The environment parameters are set in `docker run` so they can be overridden by `docker-compose`. More information in [https://docs.docker.com](https://docs.docker.com/compose/environment-variables/#/setting-environment-variables-in-containers).
 
 ```bash
-# project name
-PROJ='RADAR-Dashboard'
-  
 # to change the URI of the API
 API_URI='http://radar-restapi.eu-west-1.elasticbeanstalk.com/api'
-  
-# to use a specific branch instead of master
-BRANCH='master'
 ```
+
+The parameters are replaced in `index.html` and are global to the application.
+```html
+<script>
+  const PARAMS = {
+    API_URI: 'http://radar-restapi.eu-west-1.elasticbeanstalk.com/api'
+  };
+</script>
+```
+

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -12,23 +12,16 @@ echo '==' && echo "==> Enviroment variables"
 echo '==' && echo "==> Replace API_URI"
     cd /var/www
 
-    # search file for main.*.bundle.js
-    MAIN_FILE=$(find . -name "main.*.bundle.js")
-
     # regex patterns
+    FILE="index.html"
+    FIND="(API_URI[^\"\']*)(.*)(,)"
+    REPLACE="\\1\'${API_URI}\'\\3"
+
     # replace API_URI value
-    FIND="(API_URI:)([\"\'])(.*?)([\"\'])"
-    API_URI=$(echo ${API_URI} | sed 's|\/|\\\/|g')
-    REPLACE="\1\2$API_URI\4"
-    perl -pi -e "s/${FIND}/${REPLACE}/" ${MAIN_FILE}
+    sed -ri "s|${FIND}|${REPLACE}|" ${FILE}
 
     # check replacement
-    head -c 300 ${MAIN_FILE} && echo
-
-    # rm previous gzip file
-    # gzip main.*.bundle.js
-    rm ${MAIN_FILE}.gz
-    gzip -5 -c ${MAIN_FILE} > ${MAIN_FILE}.gz
+    cat ${FILE}
 
 echo '==' && echo "==> Starting nginx in the foreground"
     nginx -g "daemon off;"

--- a/src/app/services/chart-heart-rate.service.spec.ts
+++ b/src/app/services/chart-heart-rate.service.spec.ts
@@ -3,47 +3,18 @@ import { ChartHeartRateService } from './chart-heart-rate.service';
 import { HttpModule, XHRBackend, Response, ResponseOptions } from '@angular/http';
 import { MockBackend } from '@angular/http/testing';
 import { TimeSeries } from '../models/time-series.model';
+import { MockData } from '../test/mock-HR-data';
 
 describe('ChartHeartRateService', () => {
   let mockbackend, service;
-  let mockData = `
-  {
-    "header": {
-      "descriptive_statistic": "average",
-      "unit": "beats_per_min",
-      "effective_time_frame": {
-        "start_date_time": "2016-10-27T20:02:20Z",
-        "end_date_time": "2016-10-27T20:06:50Z"
-      }
-    },
-    "dataset": [
-      {
-        "effective_time_frame": {
-          "start_date_time": "2016-10-27T20:02:20Z",
-          "end_date_time": "2016-10-27T20:02:30Z"
-        },
-        "heart_rate": {
-          "value": 60.17274154968215
-        }
-      },
-      {
-        "effective_time_frame": {
-          "start_date_time": "2016-10-27T20:03:00Z",
-          "end_date_time": "2016-10-27T20:03:10Z"
-        },
-        "heart_rate": {
-          "value": 108.39180563508566
-        }
-      }
-    ]  
-  }`;
+  let mockData = MockData;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [HttpModule],
       providers: [
         ChartHeartRateService,
-        { provide: XHRBackend, useClass: MockBackend }
+        { provide: XHRBackend, useClass: MockBackend },
       ]
     });
   });

--- a/src/app/services/chart-heart-rate.service.ts
+++ b/src/app/services/chart-heart-rate.service.ts
@@ -3,7 +3,6 @@ import { Observable } from 'rxjs';
 import { Http } from '@angular/http';
 import { TimeSeries } from '../models/time-series.model';
 import { ErrorService } from './error.service';
-import { ENV } from '../../environments/environment';
 
 @Injectable()
 export class ChartHeartRateService {
@@ -12,7 +11,7 @@ export class ChartHeartRateService {
 
   get(): Observable<TimeSeries[]> {
     // TODO: Change when API is ready
-    return this.http.get(`${ENV.API_URI}/HR/avg/user`)
+    return this.http.get(`${PARAMS.API_URI}/HR/avg/user`)
       .map(res => res.json().dataset || [])
       .map(this.parseHeartRateData)
       .catch(ErrorService.handleError);

--- a/src/app/services/config.service.ts
+++ b/src/app/services/config.service.ts
@@ -3,7 +3,6 @@ import { Http } from '@angular/http';
 import { Observable } from 'rxjs';
 import { Config } from '../models/config.model';
 import { ErrorService } from './error.service';
-import { ENV } from '../../environments/environment';
 
 @Injectable()
 export class ConfigService {
@@ -11,7 +10,7 @@ export class ConfigService {
   constructor(private http: Http) {}
 
   get(): Observable<Config> {
-    return this.http.get(`${ENV.API_PATH}/mock-config.json`)
+    return this.http.get(`${PARAMS.API_LOCAL}/mock-config.json`)
       .map(res => res.json() || [])
       .catch(ErrorService.handleError);
   }

--- a/src/app/services/grid.service.ts
+++ b/src/app/services/grid.service.ts
@@ -3,7 +3,6 @@ import { Http } from '@angular/http';
 import { Observable } from 'rxjs';
 import { Tile } from '../models/tile.model';
 import { ErrorService } from './error.service';
-import { ENV } from '../../environments/environment';
 
 @Injectable()
 export class GridService {
@@ -11,7 +10,7 @@ export class GridService {
   constructor(private http: Http) {}
 
   get(): Observable<Tile[]> {
-    return this.http.get(`${ENV.API_PATH}/mock-grid.json`)
+    return this.http.get(`${PARAMS.API_LOCAL}/mock-grid.json`)
       .map(res => res.json().dataset || [])
       .catch(ErrorService.handleError);
   }

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -3,7 +3,6 @@ import { Http } from '@angular/http';
 import { Observable } from 'rxjs';
 import { User } from '../models/user.model';
 import { ErrorService } from './error.service';
-import { ENV } from '../../environments/environment';
 
 @Injectable()
 export class UserService {
@@ -11,7 +10,7 @@ export class UserService {
   constructor(private http: Http) {}
 
   get(): Observable<User> {
-    return this.http.get(`${ENV.API_PATH}/mock-user.json`)
+    return this.http.get(`${PARAMS.API_LOCAL}/mock-user.json`)
       .map(res => res.json().dataset || [])
       .catch(ErrorService.handleError);
   }

--- a/src/app/store/index.ts
+++ b/src/app/store/index.ts
@@ -3,7 +3,7 @@ import 'rxjs/add/operator/switchMap';
 import 'rxjs/add/operator/let';
 
 import { ActionReducer, combineReducers } from '@ngrx/store';
-import { ENV } from '../../environments/environment';
+import { environment } from '../../environments/environment';
 import { compose } from '@ngrx/core/compose';
 import { storeFreeze } from 'ngrx-store-freeze';
 import { Observable } from 'rxjs';
@@ -33,7 +33,7 @@ const productionReducer: ActionReducer<State> =
   combineReducers(reducers);
 
 export function reducer(state: any, action: any) {
-  if (ENV.PROD) {
+  if (environment.PROD) {
     return productionReducer(state, action);
   } else {
     return developmentReducer(state, action);

--- a/src/app/test/mock-HR-data.ts
+++ b/src/app/test/mock-HR-data.ts
@@ -1,0 +1,30 @@
+export const MockData = {
+  'header': {
+    'descriptive_statistic': 'average',
+    'unit': 'beats_per_min',
+    'effective_time_frame': {
+      'start_date_time': '2016-10-27T20:02:20Z',
+      'end_date_time': '2016-10-27T20:06:50Z'
+    }
+  },
+  'dataset': [
+    {
+      'effective_time_frame': {
+        'start_date_time': '2016-10-27T20:02:20Z',
+        'end_date_time': '2016-10-27T20:02:30Z'
+      },
+      'heart_rate': {
+        'value': 60.17274154968215
+      }
+    },
+    {
+      'effective_time_frame': {
+        'start_date_time': '2016-10-27T20:03:00Z',
+        'end_date_time': '2016-10-27T20:03:10Z'
+      },
+      'heart_rate': {
+        'value': 108.39180563508566
+      }
+    }
+  ]
+};

--- a/src/app/test/mock-params.ts
+++ b/src/app/test/mock-params.ts
@@ -1,0 +1,4 @@
+export const MockParams = {
+  API_URI: 'http://radar-restapi.eu-west-1.elasticbeanstalk.com/api',
+  API_LOCAL: 'assets/data'
+};

--- a/src/environments/environment.hmr.ts
+++ b/src/environments/environment.hmr.ts
@@ -1,6 +1,4 @@
-export const ENV = {
+export const environment = {
   PROD: false,
-  HMR: true,
-  API_URI: 'http://radar-restapi.eu-west-1.elasticbeanstalk.com/api',
-  API_PATH: 'assets/data'
+  HMR: true
 };

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,6 +1,4 @@
-export const ENV = {
+export const environment = {
   PROD: true,
-  HMR: false,
-  API_URI: 'http://radar-restapi.eu-west-1.elasticbeanstalk.com/api',
-  API_PATH: 'assets/data'
+  HMR: false
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -3,9 +3,7 @@
 // `ng build --env=prod` then `environment.prod.ts` will be used instead.
 // The list of which env maps to which file can be found in `angular-cli.json`.
 
-export const ENV = {
+export const environment = {
   PROD: false,
-  HMR: false,
-  API_URI: 'http://radar-restapi.eu-west-1.elasticbeanstalk.com/api',
-  API_PATH: 'assets/data'
+  HMR: false
 };

--- a/src/index.html
+++ b/src/index.html
@@ -13,6 +13,15 @@
 
   <link href="https://fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+
+  <script>
+    // GLOBAL PARAMS
+    // This object can be changed in `docker run` by setting an environment parameter
+    const PARAMS = {
+      API_URI: 'http://radar-restapi.eu-west-1.elasticbeanstalk.com/api',
+      API_LOCAL: 'assets/data'
+    };
+  </script>
 </head>
 <body>
   <app-root>

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,12 +2,12 @@ import './polyfills.ts';
 
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 import { enableProdMode } from '@angular/core';
-import { ENV } from './environments/environment';
+import { environment } from './environments/environment';
 import { AppModule } from './app/';
 
 import { hmrBootstrap } from './hmr';
 
-if (ENV.PROD) {
+if (environment.PROD) {
   enableProdMode();
 }
 
@@ -15,7 +15,7 @@ const bootstrap = () => {
   return platformBrowserDynamic().bootstrapModule(AppModule);
 };
 
-if (ENV.HMR) {
+if (environment.HMR) {
   if (module['hot']) {
     hmrBootstrap(module, bootstrap);
   } else {

--- a/src/test.ts
+++ b/src/test.ts
@@ -30,3 +30,7 @@ let context = require.context('./', true, /\.spec\.ts/);
 context.keys().map(context);
 // Finally, start Karma to run the tests.
 __karma__.start();
+
+// GLOBAL PARAMS
+import { MockParams } from './app/test/mock-params';
+(<any>window).PARAMS = MockParams;

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -3,3 +3,9 @@
 // https://www.typescriptlang.org/docs/handbook/writing-declaration-files.html
 
 declare var System: any;
+
+// GLOBAL PARAMS
+declare var PARAMS: {
+  API_URI,
+  API_LOCAL
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3401,9 +3401,9 @@ jasmine-core@~2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-2.4.1.tgz#6f83ab3a0f16951722ce07d206c773d57cc838be"
 
-jasmine-spec-reporter@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/jasmine-spec-reporter/-/jasmine-spec-reporter-3.1.0.tgz#29c74a51d25f7ca46a635d18925ba431a7be840d"
+jasmine-spec-reporter@2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/jasmine-spec-reporter/-/jasmine-spec-reporter-2.7.0.tgz#42907ff889952a129c0afc2929e195f4e74c98ff"
   dependencies:
     colors "1.1.2"
 


### PR DESCRIPTION
moving the globals to index.html allows us to change it in `docker run`, not touching the files built by angular-cli.